### PR TITLE
Add content/publish policy, ref EZP-26070

### DIFF
--- a/kernel/content/module.php
+++ b/kernel/content/module.php
@@ -641,6 +641,15 @@ $FunctionList['edit'] = array( 'Class' => $ClassID,
                                'Language' => $Language );
 $FunctionList['edit'] = array_merge( $FunctionList['edit'], $stateLimitations );
 
+$FunctionList['publish'] = array( 'Class' => $ClassID,
+                                  'Section' => $SectionID,
+                                  'Owner' => $AssignedEdit,
+                                  'Group' => $AssignedGroup,
+                                  'Node' => $Node,
+                                  'Subtree' => $Subtree,
+                                  'Language' => $Language );
+$FunctionList['publish'] = array_merge( $FunctionList['publish'], $stateLimitations );
+
 $FunctionList['manage_locations'] = array( 'Class' => $ClassID,
                                            'Section' => $SectionID,
                                            'Owner' => $Assigned,


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26070
> https://github.com/ezsystems/ezpublish-kernel/pull/1868

This PR adds a `content/publish` policy, unused by the Legacy itself, instead used for compatibility with eZ Publish 6.8.x kernel.