### PR TITLE
PHP8 support

### DIFF
--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -1743,8 +1743,17 @@ class eZINI
      */
     function findSettingPlacement( $path )
     {
-        if ( is_array( $path ) && isset( $path[0] ) )
-            $path = $path[0];
+        if ( is_array( $path ) )
+        {
+            if( isset( $path[0] ) )
+            {
+                $path = $path[0];
+            }
+            else
+            {
+                return 'undefined';
+            }
+        }
 
         // changing $path so that it's relative the root eZ Publish (legacy)
         $path = str_replace( __DIR__ . "/../../../", "", $path );


### PR DESCRIPTION
I'm running this code with PHP8.2 and it fails with following error message:

Unexpected error, the message was : explode(): Argument #2 ($string) must be of type string, array given in ./ezpublish_legacy/lib/ezutils/classes/ezini.php on line 1751

As you can see in the original code, sometimes this function gets an array for the $path variable. In that case, the original code was picking the first element of the array if it exists. In case of an empty array, $path is still an array. 

The PHP function explode `explode( '/', $path );` expects a string for $path. PHP7 and lower just return FALSE. PHP8 triggers an error and stops the execution.

My code changes just make sure that $path is a string and it returns 'undefined' in case of an empty array for the $path variable.