### PR TITLE
Updated: Bugfix for class properties for php8. Warning: PHP: E_DEPREC…

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -1021,6 +1021,8 @@ class eZFSFileHandler implements eZClusterFileHandlerInterface
 
     public $metaData = null;
     public $filePath;
+    public $Mutex;
+    public $lifetime;
 }
 
 ?>

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -2993,6 +2993,7 @@ WHERE user_id = '" . $userID . "' AND
     public $Groups;
     public $OriginalPassword;
     public $OriginalPasswordConfirm;
+    public $AccessArray;
 
     /**
      * Holds user cache like user info and access array

--- a/kernel/classes/ezcontentlanguage.php
+++ b/kernel/classes/ezcontentlanguage.php
@@ -941,4 +941,9 @@ class eZContentLanguage extends eZPersistentObject
     {
         return ( 8 * PHP_INT_SIZE ) - 2;
     }
+
+    public $ID;
+    public $Name;
+    public $Locale;
+    public $Disabled;
 }

--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -1437,6 +1437,8 @@ class eZPersistentObject
 
         return $attrName;
     }
+
+    public $ContentObjectID;
 }
 
 ?>

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -1042,6 +1042,7 @@ class eZTemplateDesignResource extends eZTemplateFileResource
 
     public $Keys;
     public $OverrideSiteAccess = false;
+    public $KeyStack;
 }
 
 ?>

--- a/lib/ezdb/classes/ezdbinterface.php
+++ b/lib/ezdb/classes/ezdbinterface.php
@@ -1826,6 +1826,11 @@ class eZDBInterface
      * @var int One of the eZDB::ERROR_HANDLING_* constants
      */
     protected $errorHandling = eZDB::ERROR_HANDLING_STANDARD;
+
+    public $IsInternalCharset;
+    public $SlowSQLTimeout;
+    public $QueryAnalysisOutput;
+    public $AttributeVariableMap;
 }
 
 ?>

--- a/lib/ezlocale/classes/ezlocale.php
+++ b/lib/ezlocale/classes/ezlocale.php
@@ -1668,7 +1668,27 @@ class eZLocale
     public $TimeArray;
     public $DateArray;
     public $TimePHPArray;
+    public $TimeSlashInputArray;
+    public $TimeSlashOutputArray;
+    public $DateTimeSlashInputArray;
+    public $DateSlashOutputArray;
+    public $DateTimeSlashOutputArray;
+    public $HTTPLocaleCode;
+    public $functionMap;
+    public $LocaleCode;
+    public $TranslationCode;
+    public $Charset;
+    public $OverrideCharset;
+    public $DateTimeFormat;
+    public $ShortDateTimeFormat;
+    public $CurrencyName;
+    public $CurrencyShortName;
+    public $AllowedCharsets;
+    public $DateSlashInputArray;
     public $DatePHPArray;
+    public $DateTimeArray;
+    public $DateTimePHPArray;
+
     //@}
 
     //@{

--- a/lib/ezsession/classes/ezpsessionhandler.php
+++ b/lib/ezsession/classes/ezpsessionhandler.php
@@ -195,5 +195,7 @@ abstract class ezpSessionHandler
     {
         return session_start();
     }
+
+    public $userHasCookie;
 }
 ?>

--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -2715,6 +2715,9 @@ class eZTemplate
 
 //     public $CurrentRelatedResource;
 //     public $CurrentRelatedTemplateName;
+
+   public $MaxLevelWarning;
+   public $TemplateFetchList;
 }
 
 ?>

--- a/lib/ezutils/classes/ezphpcreator.php
+++ b/lib/ezutils/classes/ezphpcreator.php
@@ -1336,13 +1336,16 @@ print( $values['MyValue'] );
     /// \privatesection
     public $PHPDir;
     public $PHPFile;
+    public $FilePrefix;
     public $FileResource;
     public $Elements;
     public $TextChunks;
     public $isAtomic;
+    public $TemporaryCounter;
     public $tmpFilename;
     public $requestedFilename;
     public $Spacing = true;
+    public $ClusterHandler;
     public $ClusteringEnabled = false;
     public $ClusterFileScope  = false;
 }


### PR DESCRIPTION
…ATED Creation of dynamic property

There are lots more refactoring that needs to be done in the lib and kernel to fix this bug properly. This was done manually by loading the content/view/sitemap module and fixing the errors. It's a good start but automated tools may be able to fix the shear bulk of these faster I'm not certain. because there are a whole lot of these depredations in ezpl code base.

Please let us know what you think?

Respectfully,
Brookins Consulting