### PR TITLE
Continued: Further Bugfixes for dynamic class properties

### DIFF
--- a/kernel/classes/ezclusterfilefailure.php
+++ b/kernel/classes/ezclusterfilefailure.php
@@ -54,5 +54,8 @@ class eZClusterFileFailure
     {
         return $this->Message;
     }
+
+    public $Errno;
+    public $Message;
 }
 ?>

--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -2016,6 +2016,7 @@ You will need to change the class of the node by using the swap functionality.' 
     public $IsContainer;
     public $CanInstantiateLanguages;
     public $LanguageMask;
+    public $DataMap;
 
     /**
      * In-memory cache for class identifiers / id matching

--- a/kernel/classes/ezcontentclassattribute.php
+++ b/kernel/classes/ezcontentclassattribute.php
@@ -1137,6 +1137,8 @@ class eZContentClassAttribute extends eZPersistentObject
     public $IsRequired;
     public $IsInformationCollector;
     public $Module;
+    public $DataTextI18nList;
+
     // Used locale for use by datatypes in class/edit when storing data
     protected $EditLocale = false;
 

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -6737,6 +6737,9 @@ class eZContentObject extends eZPersistentObject
      */
     public $InputRelationList = array();
 
+    public $Permissions;
+    public $ContentObject;
+
     /**
      * Cache for the state ID array
      *

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -6481,6 +6481,9 @@ class eZContentObjectTreeNode extends eZPersistentObject
      */
     public $ClassName = null;
 
+    public $ContentObject;
+    public $Permissions;
+
     /**
      * @var int|null Whether the node's class is a container (1) or not (0)
      */

--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -1438,7 +1438,57 @@ class eZPersistentObject
         return $attrName;
     }
 
+    public $ID;
     public $ContentObjectID;
+    public $SectionID;
+    public $OwnerID;
+    public $ClassID;
+    public $Published;
+    public $Modified;
+    public $CurrentVersion;
+    public $Status;
+    public $RemoteID;
+    public $LanguageMask;
+    public $InitialLanguageID;
+    public $NodeID;
+    public $ParentNodeID;
+    public $MainNodeID;
+    public $ContentObjectVersion;
+    public $ContentObjectIsPublished;
+    public $Depth;
+    public $SortField;
+    public $SortOrder;
+    public $Priority;
+    public $ModifiedSubNode;
+    public $PathString;
+    public $PathIdentificationString;
+    public $IsHidden;
+    public $IsInvisible;
+    public $UserID;
+    public $Name;
+    public $Locale;
+    public $Identifier;
+    public $NavigationPartIdentifier;
+    public $SerializedDescriptionList;
+    public $URLAliasName;
+    public $AlwaysAvailable;
+    public $CanTranslate;
+    public $DataInt1;
+    public $DataInt2;
+    public $DataInt3;
+    public $DataInt4;
+    public $DataFloat1;
+    public $DataFloat2;
+    public $DataFloat3;
+    public $DataFloat4;
+    public $DataText1;
+    public $DataText2;
+    public $DataText3;
+    public $DataText4;
+    public $DataText5;
+    public $SerializedDataText;
+    public $Category;
+    public $CanTranslate;
 }
 
 ?>

--- a/kernel/classes/ezpolicy.php
+++ b/kernel/classes/ezpolicy.php
@@ -451,6 +451,7 @@ class eZPolicy extends eZPersistentObject
     public $LimitValue;
     public $LimitIdentifier;
     public $UserRoleID;
+    public $Limitations;
 
 }
 

--- a/kernel/common/ezi18noperator.php
+++ b/kernel/common/ezi18noperator.php
@@ -182,6 +182,7 @@ class eZi18nOperator
     public $Operators;
     public $Name;
     public $ExtensionName;
+    public $DynamicName;
 }
 
 ?>

--- a/kernel/common/ezurloperator.php
+++ b/kernel/common/ezurloperator.php
@@ -1017,6 +1017,12 @@ CODEPIECE;
     public $Operators;
     public $URLName, $URLRootName, $DesignName, $ImageName;
     public $Sys;
+    public $SysName;
+    public $ExtName;
+    public $HTTPName;
+    public $ININame;
+    public $ININameHasVariable;
+    public $HTTPNameHasVariable;
 }
 
 ?>

--- a/lib/ezi18n/classes/eztstranslator.php
+++ b/lib/ezi18n/classes/eztstranslator.php
@@ -753,6 +753,9 @@ class eZTSTranslator extends eZTranslatorHandler
     public $UseCache;
     public $BuildCache;
     public $CachedMessages;
+    public $Locale;
+    public $HasRestoredCache;
+    public $RootCache;
 
     /**
      * Translation expiry key used by eZExpiryHandler to manage translation caches

--- a/lib/eztemplate/classes/eztemplatearrayoperator.php
+++ b/lib/eztemplate/classes/eztemplatearrayoperator.php
@@ -2101,6 +2101,28 @@ class eZTemplateArrayOperator
     public $Operators;
     public $ArrayName;
     public $HashName;
+    public $ArrayPrependName;
+    public $PrependName;
+    public $ArrayAppendName;
+    public $AppendName;
+    public $ArrayMergeName;
+    public $MergeName;
+    public $ContainsName;
+    public $CompareName;
+    public $ExtractName;
+    public $ExtractLeftName;
+    public $ExtractRightName;
+    public $BeginsWithName;
+    public $EndsWithName;
+    public $ImplodeName;
+    public $ExplodeName;
+    public $RepeatName;
+    public $ReverseName;
+    public $InsertName;
+    public $RemoveName;
+    public $ReplaceName;
+    public $UniqueName;
+    public $ArraySumName;
 }
 
 ?>

--- a/lib/eztemplate/classes/eztemplatecontroloperator.php
+++ b/lib/eztemplate/classes/eztemplatecontroloperator.php
@@ -249,6 +249,8 @@ class eZTemplateControlOperator
 
     /// The array of operators
     public $Operators;
+    public $CondName;
+    public $FirstSetName;
 }
 
 ?>

--- a/lib/eztemplate/classes/eztemplatelocaleoperator.php
+++ b/lib/eztemplate/classes/eztemplatelocaleoperator.php
@@ -514,6 +514,10 @@ class eZTemplateLocaleOperator
     public $LocaleName;
     public $DateTimeName;
     public $CurrentDateName;
+    public $LocaleFetchName;
+    public $MakeTimeName;
+    public $MakeDateName;
+    public $GetTimeName;
 }
 
 ?>

--- a/lib/eztemplate/classes/eztemplatestringoperator.php
+++ b/lib/eztemplate/classes/eztemplatestringoperator.php
@@ -728,6 +728,23 @@ class eZTemplateStringOperator
 
     /// The array of operators, used for registering operators
     public $Operators;
+    public $UpcaseName;
+    public $DowncaseName;
+    public $Count_wordsName;
+    public $Count_charsName;
+    public $TrimName;
+    public $BreakName;
+    public $WrapName;
+    public $ShortenName;
+    public $PadName;
+    public $UpfirstName;
+    public $UpwordName;
+    public $SimplifyName;
+    public $WashName;
+    public $ChrName;
+    public $OrdName;
+    public $phpMap;
+    public $customMap;
 }
 
 ?>

--- a/lib/eztemplate/classes/eztemplatetextoperator.php
+++ b/lib/eztemplate/classes/eztemplatetextoperator.php
@@ -276,6 +276,7 @@ class eZTemplateTextOperator
     /// \privatesection
     public $ConcatName;
     public $Operators;
+    public $IndentName;
 }
 
 ?>

--- a/lib/eztemplate/classes/eztemplatetoolbarfunction.php
+++ b/lib/eztemplate/classes/eztemplatetoolbarfunction.php
@@ -352,6 +352,8 @@ class eZTemplateToolbarFunction
     {
         return false;
     }
+
+    public $BlockName;
 }
 
 ?>

--- a/lib/eztemplate/classes/eztemplatetypeoperator.php
+++ b/lib/eztemplate/classes/eztemplatetypeoperator.php
@@ -423,6 +423,19 @@ class eZTemplateTypeOperator
     public $Operators;
     /// The "less than" name
     public $IsArrayName;
+    public $IsBooleanName;
+    public $IsIntegerName;
+    public $IsFloatName;
+    public $IsNumericName;
+    public $IsStringName;
+    public $IsObjectName;
+    public $IsClassName;
+    public $IsNullName;
+    public $IsSetName;
+    public $IsUnsetName;
+    public $GetTypeName;
+    public $GetClassName;
+    public $PHPNameMap;
 }
 
 ?>

--- a/lib/ezutils/classes/ezmutex.php
+++ b/lib/ezutils/classes/ezmutex.php
@@ -221,6 +221,8 @@ class eZMutex
 
     public $Name;
     public $FileName;
+    public $MetaFileName;
+
 }
 
 ?>

--- a/lib/ezutils/classes/ezuri.php
+++ b/lib/ezutils/classes/ezuri.php
@@ -33,6 +33,8 @@ class eZURI
      */
     public $URI;
 
+    public $OriginalURI;
+
     /**
      * The URI array
      *


### PR DESCRIPTION
Hello @emodric 

Here is another wave of tediously coded bugfixes for php8 this time focusing again on dynamic properties deprecation warnings and fatal errors.

Please let me know how this finds you.

Cheers,
Brookins Consulting