### PR TITLE
 Updated: Further Bugfixes for class properties for php8. Warning: PH…

### DIFF
--- a/kernel/classes/datatypes/eztext/eztexttype.php
+++ b/kernel/classes/datatypes/eztext/eztexttype.php
@@ -260,6 +260,8 @@ class eZTextType extends eZDataType
     {
         return true;
     }
+
+    public $Attributes;
 }
 
 eZDataType::register( eZTextType::DATA_TYPE_STRING, "eZTextType" );

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -2994,6 +2994,8 @@ WHERE user_id = '" . $userID . "' AND
     public $OriginalPassword;
     public $OriginalPasswordConfirm;
     public $AccessArray;
+    public $ContentObjectID;
+
 
     /**
      * Holds user cache like user info and access array

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -1506,6 +1506,20 @@ class eZContentObjectAttribute extends eZPersistentObject
     public $ContentClassAttributeIsRequired;
 
     public $ValidationParameters = array();
+    public $InputParameters;
+    public $HasValidationError;
+    public $DataTypeCustom;
+    public $DataTypeString;
+    public $Version;
+    public $LanguageCode;
+    public $LanguageID;
+    public $AttributeOriginalID;
+    public $SortKeyInt;
+    public $SortKeyString;
+    public $DataText;
+    public $DataInt;
+    public $DataFloat;
+
 }
 
 ?>

--- a/kernel/classes/ezdatatype.php
+++ b/kernel/classes/ezdatatype.php
@@ -1514,6 +1514,8 @@ class eZDataType
     public $DataTypeString;
     /// The descriptive name of the datatype, usually used for displaying to the user
     public $Name;
+
+    
 }
 
 ?>

--- a/kernel/classes/ezpolicy.php
+++ b/kernel/classes/ezpolicy.php
@@ -452,6 +452,10 @@ class eZPolicy extends eZPersistentObject
     public $LimitIdentifier;
     public $UserRoleID;
     public $Limitations;
+    public $RoleID;
+    public $ModuleName;
+    public $FunctionName;
+    public $OriginalID;
 
 }
 

--- a/kernel/classes/ezpolicylimitation.php
+++ b/kernel/classes/ezpolicylimitation.php
@@ -383,6 +383,11 @@ class eZPolicyLimitation extends eZPersistentObject
     // Used for assign subtree matching
     public $LimitValue;
 
+    public $PolicyID;
+    public $LimitationID;
+    public $Value;
+    public $Values;
+
 }
 
 ?>

--- a/kernel/classes/ezpolicylimitationvalue.php
+++ b/kernel/classes/ezpolicylimitationvalue.php
@@ -114,6 +114,9 @@ class eZPolicyLimitationValue extends eZPersistentObject
                                           array( "value" => $value ) );
     }
 
+    public $LimitationID;
+    public $Value;
+
 }
 
 ?>

--- a/kernel/classes/ezrole.php
+++ b/kernel/classes/ezrole.php
@@ -929,6 +929,8 @@ class eZRole extends eZPersistentObject
     public $Policies;
     public $AccessArray;
     public $CachePolicies = true;
+    public $Version;
+    public $IsNew;
 }
 
 ?>

--- a/lib/ezimage/classes/ezimagegdhandler.php
+++ b/lib/ezimage/classes/ezimagegdhandler.php
@@ -753,6 +753,23 @@ class eZImageGDHandler extends eZImageHandler
     public $Executable;
     public $PreParameters;
     public $PostParameters;
+
+    public $InputMap;
+    public $OutputMap;
+    public $OutputQualityMap;
+    public $FilterFunctionMap;
+    public $LuminanceColorScales;
+    public $ThresholdList;
+    public $HandlerName;
+    public $SupportedInputMIMETypes;
+    public $SupportedOutputMIMETypes;
+    public $ConversionRules;
+    public $OutputRewriteType;
+    public $Filters;
+    public $FilterMap;
+    public $SupportImageFilters;
+    public $MIMETagMap;
+    public $IsEnabled;
 }
 
 ?>

--- a/lib/ezimage/classes/ezimagemanager.php
+++ b/lib/ezimage/classes/ezimagemanager.php
@@ -1428,6 +1428,19 @@ class eZImageManager
     public $RuleMap;
     public $MIMETypes;
     public $Types = array();
+    public $SupportedFormats;
+    public $SupportedMIMEMap;
+    public $AliasList;
+    public $Factories;
+    public $ImageFilters;
+    public $MIMETypeSettings;
+    public $MIMETypeSettingsMap;
+    public $QualityValues;
+    public $QualityValueMap;
+    public $QualityValueMapOverride;
+    public $TemporaryImageDirPath;
+    public $ConversionRules;
+    
 
     /**
      * Singleton instance of eZImageManager used by {@link eZImageManager::instance()}

--- a/lib/ezimage/classes/ezimageshellhandler.php
+++ b/lib/ezimage/classes/ezimageshellhandler.php
@@ -273,7 +273,19 @@ class eZImageShellHandler extends eZImageHandler
     public $ExecutableWin32;
     public $ExecutableMac;
     public $ExecutableUnix;
-
+    public $HandlerName;
+    public $SupportedInputMIMETypes;
+    public $SupportedOutputMIMETypes;
+    public $ConversionRules;
+    public $OutputRewriteType;
+    public $Filters;
+    public $FilterMap;
+    public $SupportImageFilters;
+    public $MIMETagMap;
+    public $IsEnabled;
+    public $UseTypeTag;
+    public $QualityParameters;
+    public $FrameRangeParameters;
 }
 
 ?>

--- a/lib/ezutils/classes/ezexpiryhandler.php
+++ b/lib/ezutils/classes/ezexpiryhandler.php
@@ -199,6 +199,9 @@ class eZExpiryHandler
      * @var bool
      */
     public $IsModified;
+
+    public $CacheFile;
+    
 }
 
 ?>

--- a/lib/ezutils/classes/ezmodule.php
+++ b/lib/ezutils/classes/ezmodule.php
@@ -241,6 +241,9 @@ class eZModule
     public $UIComponentMatch;
 
     public static $useExceptions;
+    public $FunctionList;
+    public $NavigationParts;
+
 
     /**
      * Constructor. Initializes the module.

--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -120,6 +120,10 @@ class eZSys
      */
     public $OSType;
 
+    public $Attributes;
+    public $OS;
+    public $BackupFilename;
+
     /**
      * Holds server variables as read automatically or provided by unit tests
      * Only used by init functionality as other calls will need to use live data direclty from globals.


### PR DESCRIPTION
…P: E_DEPRECATED Creation of dynamic property. Part 3.

Hello @emodric 

Here is another wave of tested changes which greatly reduce deprecation warnings logged to eZDebug. This was done by hand while manually re-loading a ezp homepage and fixing the deprecation notices. As this is a very big task sigh much more work needs to be done but I am taking this work in smaller sessions to avoid burnout. 

We tried using chat gpt 3.5 to generate a rector ruleset to use as a automated method of solving these deprecations but have had no luck in getting the resulting solution to run without fatal errors. help in this area is welcome.

Cheers,
Brookins Consulting