### PR TITLE
Updated: Update composer.json to specifically obtain key zetacomponen…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "zetacomponents/authentication-database-tiein": "~1.2",
         "zetacomponents/cache": "~1.6",
         "zetacomponents/configuration": "~1.4",
-        "zetacomponents/console-tools": "~1.7",
+        "zetacomponents/console-tools": "^1.7.3",
         "zetacomponents/database": "~1.5",
         "zetacomponents/debug": "~1.3",
         "zetacomponents/event-log": "~1.5",
@@ -59,10 +59,10 @@
         "zetacomponents/signal-slot": "~1.2",
         "zetacomponents/system-information": "~1.1",
         "zetacomponents/webdav": "~1.1",
-        "zetacomponents/base": "^1.9"
+        "zetacomponents/base": "^1.9.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.36",
+        "phpunit/phpunit": "10.0.0",
         "zetacomponents/php-generator": "~1.1"
     },
     "autoload": {


### PR DESCRIPTION
…ts base and console-tools php8 bugfixes

Hello @emodric 

Today I write with another key zetacomponents and ezdebug log warnings bugfixes. This reduces the warnings to zero when properly installed.

We just want to include the latest bugfixes from the upstream zeta project so we have clean installed on php8.2 and soon 8.3.

And isn't it interesting we can support php 7.4 -> 8.3 today with no further changes. What a time we live in :)

Cheers,
Brookins Consulting