### PR TITLE
Consideration of changed error handling of PHP get_class function

### DIFF
--- a/lib/eztemplate/classes/eztemplatetypeoperator.php
+++ b/lib/eztemplate/classes/eztemplatetypeoperator.php
@@ -250,7 +250,7 @@ class eZTemplateTypeOperator
 
             case $this->IsClassName:
             {
-                $code .= '( strtolower( get_class( %1% ) ) == strtolower( %2% ) );';
+                $code .= '( strtolower( is_object( %1% ) ? get_class( %1% ) : "" ) == strtolower( %2% ) );';
                 $values[] = $parameters[1];
             } break;
 
@@ -276,7 +276,7 @@ class eZTemplateTypeOperator
 
             case $this->GetClassName:
             {
-                $code .= 'strtolower( get_class( %1% ) );';
+                $code .= 'strtolower( is_object( %1% ) ? get_class( %1% ) : "" );';
             } break;
         }
 

--- a/lib/eztemplate/classes/eztemplatetypeoperator.php
+++ b/lib/eztemplate/classes/eztemplatetypeoperator.php
@@ -250,7 +250,7 @@ class eZTemplateTypeOperator
 
             case $this->IsClassName:
             {
-                $code .= '( strtolower( is_object( %1% ) ? get_class( %1% ) : "" ) == strtolower( %2% ) );';
+                $code .= '( is_object( %1% ) ? strtolower( get_class( %1% ) ) == strtolower( %2% ) : false );';
                 $values[] = $parameters[1];
             } break;
 
@@ -276,7 +276,7 @@ class eZTemplateTypeOperator
 
             case $this->GetClassName:
             {
-                $code .= 'strtolower( is_object( %1% ) ? get_class( %1% ) : "" );';
+                $code .= '( is_object( %1% ) ? strtolower( get_class( %1% ) ) : "" );';
             } break;
         }
 


### PR DESCRIPTION
Since PHP 8.0.0:
Calling get_class function from outside a class, without any arguments, will now throw an Error. Previously, an E_WARNING was raised and the function returned false.