### PR TITLE
Fix: Creating or removing node URL aliases results in a fatal error

### DIFF
--- a/kernel/content/urlalias.php
+++ b/kernel/content/urlalias.php
@@ -51,7 +51,7 @@ if ( $Module->isCurrentAction( 'RemoveAllAliases' ) )
         $filter->prepare();
     }
     $infoCode = "feedback-removed-all";
-    ezpEvent::getInstance()->notify( 'content/cache', array( $NodeID ) );
+    ezpEvent::getInstance()->notify( 'content/cache', array( array( $NodeID ) ) );
 }
 else if ( $Module->isCurrentAction( 'RemoveAlias' ) )
 {
@@ -71,7 +71,7 @@ else if ( $Module->isCurrentAction( 'RemoveAlias' ) )
             }
         }
         $infoCode = "feedback-removed";
-        ezpEvent::getInstance()->notify( 'content/cache', array( $NodeID ) );
+        ezpEvent::getInstance()->notify( 'content/cache', array( array( $NodeID ) ) );
     }
 }
 else if ( $Module->isCurrentAction( 'NewAlias' ) )
@@ -153,7 +153,7 @@ else if ( $Module->isCurrentAction( 'NewAlias' ) )
                 $infoCode = "feedback-alias-created";
             }
             $aliasText = false;
-            ezpEvent::getInstance()->notify( 'content/cache', array( $NodeID ) );
+            ezpEvent::getInstance()->notify( 'content/cache', array( array( $NodeID ) ) );
         }
     }
 }


### PR DESCRIPTION
On a legacy bridge install, creating or removing a node URL alias (via content/urlalias/<node_id>) results in this error:

`Unexpected error, the message was : Argument 1 passed to eZ\Bundle\EzPublishLegacyBundle\Cache\SwitchableHttpCachePurger::purge() must be of the type array, string given, called in ezpublish_legacy/kernel/private/classes/ezpevent.php on line 138 in vendor/netgen/ibexa-legacy-bridge/bundle/Cache/SwitchableHttpCachePurger.php on line 38`

In short, the first parameter in the array or parameters sent to the "content/cache" event needs to be an array itself:

`ezpEvent::getInstance()->notify( 'content/cache', array( array( $NodeID ) ) );`

This is because SwitchableHttpCachePurger::purge() requires the array: https://github.com/netgen/ibexa-legacy-bridge/blob/3.x/bundle/Cache/SwitchableHttpCachePurger.php#L38