### PR TITLE
Updated: Refactor method to avoid nasty errors when display_errors is On

### DIFF
--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -310,14 +310,20 @@ class eZINI
      * Check whether a specified parameter in a specified section is set in a specified file
      *
      * @deprecated Since 4.4
-     * @param string fileName file name (optional)
-     * @param string rootDir directory (optional)
+     * @param string fileName file name (optional/psudo required)
+     * @param string rootDir directory (optional/psudo required)
      * @param string section section name
      * @param string parameter parameter name
      * @return bool True if the the parameter is set.
      */
-    static function parameterSet( $fileName = 'site.ini', $rootDir = 'settings', &$section, &$parameter )
+    static function parameterSet( string $fileName = null, string $rootDir = null, &$section, &$parameter )
     {
+        if( $fileName == null )
+            $fileName = 'site.ini';
+
+        if( $rootDir == null )
+            $fileName = 'settings';
+
         if ( !eZINI::exists( $fileName, $rootDir ) )
             return false;
 


### PR DESCRIPTION
Hello @emodric 

Today I write with a simple but important bugfix that causes visual errors at the top of the page on first page load with display_errors On.

I wasn't sure how best to fix the error but after some research I found this mix of code did the job while being respectful of the original intent of the code.

Thank you for your continued support!

Cheers,
Brookins Consulting