### PR TITLE
Updated: Refactor to address php8 deprecations

### DIFF
--- a/lib/eztemplate/classes/eztemplatecompiledloop.php
+++ b/lib/eztemplate/classes/eztemplatecompiledloop.php
@@ -65,8 +65,8 @@ class eZTemplateCompiledLoop
     {
         $fName      = $this->Name;
         $uniqid     = $this->UniqID;
-        $this->NewNodes[] = eZTemplateNodeTool::createVariableUnsetNode( "${fName}_sequence_array_$uniqid" );
-        $this->NewNodes[] = eZTemplateNodeTool::createVariableUnsetNode( "${fName}_sequence_var_$uniqid" );
+        $this->NewNodes[] = eZTemplateNodeTool::createVariableUnsetNode( "{$fName}_sequence_array_$uniqid" );
+        $this->NewNodes[] = eZTemplateNodeTool::createVariableUnsetNode( "{$fName}_sequence_var_$uniqid" );
         $this->NewNodes[] = eZTemplateNodeTool::createVariableUnsetNode( $this->Parameters['sequence_var'][0][1] );
     }
 
@@ -86,8 +86,8 @@ class eZTemplateCompiledLoop
                                                                     $this->Parameters['sequence_array'],
                                                                     $this->NodePlacement,
                                                                     array( 'treat-value-as-non-object' => true, 'text-result' => false ),
-                                                                    "${fName}_sequence_array_$uniqid" );
-        $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$${fName}_sequence_var_$uniqid = current( \$${fName}_sequence_array_$uniqid );\n" );
+                                                                    "{$fName}_sequence_array_$uniqid" );
+        $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$${$fName}_sequence_var_$uniqid = current( \$${fName}_sequence_array_$uniqid );\n" );
     }
 
     /*!
@@ -100,7 +100,7 @@ class eZTemplateCompiledLoop
 
         $fName    = $this->Name;
         $uniqid   = $this->UniqID;
-        $seqVar   = "${fName}_sequence_var_$uniqid";
+        $seqVar   = "{$fName}_sequence_var_$uniqid";
         $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "// setting current sequence value" );
         $this->NewNodes[] = eZTemplateNodeTool::createVariableNode( false, $seqVar, $this->NodePlacement, array(),
                                                                     $this->Parameters['sequence_var'][0][1],
@@ -117,8 +117,8 @@ class eZTemplateCompiledLoop
 
         $fName    = $this->Name;
         $uniqid   = $this->UniqID;
-        $seqArray = "${fName}_sequence_array_$uniqid";
-        $seqVar   = "${fName}_sequence_var_$uniqid";
+        $seqArray = "{$fName}_sequence_array_$uniqid";
+        $seqVar   = "{$fName}_sequence_var_$uniqid";
         $alterSeqValCode =
             "if ( ( \$$seqVar = next( \$$seqArray ) ) === false )\n" .
             "{\n" .


### PR DESCRIPTION
Hello @emodric 

I have one more (i hope it's the near the end) bugfix for eztemplate library.

This fixes most of this classes use of deprecated string interpolation see here:
https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

On line 90 is one last syntax that is escaped that I can not seem to find the correct replacement perhaps others could build upon my changes to fix what seems like the last boot error on stale cache that their is. the rest are hiding in the source code of the core product and community extensions.

Thank you for your continued support.

Cheers,
Brookins Consulting