### PR TITLE
Updated: Refactor deprecated variable usage for php8. Bugfix

### DIFF
--- a/lib/eztemplate/classes/eztemplatecompiledloop.php
+++ b/lib/eztemplate/classes/eztemplatecompiledloop.php
@@ -87,7 +87,7 @@ class eZTemplateCompiledLoop
                                                                     $this->NodePlacement,
                                                                     array( 'treat-value-as-non-object' => true, 'text-result' => false ),
                                                                     "{$fName}_sequence_array_$uniqid" );
-        $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$${$fName}_sequence_var_$uniqid = current( \$${fName}_sequence_array_$uniqid );\n" );
+        $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "{\$$fName}_sequence_var_$uniqid = current( {\$$fName}_sequence_array_$uniqid );\n" );
     }
 
     /*!


### PR DESCRIPTION
Hello @emodric 

Today I write with another simple lib/eztemplate related bugfix that prevents warnings with display_errors enabled.

Thank you for your continued support!

Cheers,
Brookins Consulting