### PR TITLE
Updated: Bugfix for template system foreach function. Fixes current debug notices in length.

### DIFF
--- a/lib/eztemplate/classes/eztemplatecompiledloop.php
+++ b/lib/eztemplate/classes/eztemplatecompiledloop.php
@@ -87,7 +87,7 @@ class eZTemplateCompiledLoop
                                                                     $this->NodePlacement,
                                                                     array( 'treat-value-as-non-object' => true, 'text-result' => false ),
                                                                     "{$fName}_sequence_array_$uniqid" );
-        $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$${$fName}_sequence_var_$uniqid = current( \$${fName}_sequence_array_$uniqid );\n" );
+        $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "\${$fName}_sequence_var_$uniqid = current( \${$fName}_sequence_array_$uniqid );\n" );
     }
 
     /*!
@@ -128,7 +128,6 @@ class eZTemplateCompiledLoop
         $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( "// sequence iteration" );
         $this->NewNodes[] = eZTemplateNodeTool::createCodePieceNode( $alterSeqValCode );
     }
-
 
     /*
      * Compiles loop children (=code residing between start and end tags of the loop).

--- a/lib/eztemplate/classes/eztemplateforeachfunction.php
+++ b/lib/eztemplate/classes/eztemplateforeachfunction.php
@@ -126,6 +126,19 @@ class eZTemplateForeachFunction
         $variableStack   = "fe_variable_stack_$uniqid";
         $namesArray = array( $array, $arrayKeys, $nItems, $nItemsProcessed, $i, $key, $val, $offset, $max, $reverse, $firstVal, $lastVal );
 
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$array = [];" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$arrayKeys = [];" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$nItems = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$nItemsProcessed  = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$i = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$key = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$val = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$offset = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$max = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$reverse = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$firstVal = 0;" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$lastVal = 0;" );
+
         $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "if ( !isset( \$$variableStack ) ) \$$variableStack = [];" );
         $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$" . $variableStack ."[] = @compact( '" . implode( "', '", $namesArray ) . "' );" );
 
@@ -182,8 +195,8 @@ class eZTemplateForeachFunction
                                                                "{" );
         $newNodes[] = eZTemplateNodeTool::createSpacingIncreaseNode();
 
-        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$key = \$${arrayKeys}[\$$i];" );
-        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$val = \$${array}[\$$key];" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$key = \${$arrayKeys}[\$$i];" );
+        $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$val = \${$array}[\$$key];" );
 
         // export $itemVar
         $newNodes[] = eZTemplateNodeTool::createVariableNode( false, "$val", $nodePlacement, array(),


### PR DESCRIPTION
Updated: Bugfix for template system foreach function to fix error notices on undefined variables in php 8.2+

Hello @emodric 

This is a continuation of the previous pr on the lib eztemplate sub systems to prevent php 8.2+ deprecation notices and unset variable notices. This pr is particularly important to the developers and users of the ibexa4 branch as it finally solves a large block of debug output warnings we caused previously by fixing the template system issues so slowly.

There are still a view more deprecation warnings left to fix to claim no undesirable warnings left to fix but we are close.

Thanks again for your continued support!

Respectfully,
Brookins Consulting