### PR TITLE
Bugfix: Incorrect date/time attributes after export within the ezpkg (e.g. contentobject.xml)

### DIFF
--- a/lib/ezlocale/classes/ezdateutils.php
+++ b/lib/ezlocale/classes/ezdateutils.php
@@ -45,7 +45,7 @@ class eZDateUtils
                          9 => 'Sep', 10 => 'Oct', 11 => 'Nov', 12 => 'Dec' );
 
         $mon = $months[$month];
-        return gmdate( $wkday . ", d " . $mon . " Y H:i:s" . " GMT", $timestamp );
+        return $wkday . gmdate( ", d ", $timestamp ) . $mon . gmdate( " Y H:i:s", $timestamp ) . " GMT" ;
     }
 
     /*!
@@ -78,7 +78,7 @@ class eZDateUtils
                          5 => 'May', 6 => 'Jun', 7 => 'Jul', 8 => 'Aug',
                          9 => 'Sep', 10 => 'Oct', 11 => 'Nov', 12 => 'Dec' );
         $mon = $months[$month];
-        return gmdate( $weekday . ", d-" . $mon . "-Y H:i:s" . " GMT", $timestamp );
+        return $weekday . gmdate( ", d-", $timestamp ) . $mon . gmdate("-Y H:i:s", $timestamp) . " GMT" ;
     }
 
     /*!


### PR DESCRIPTION
If, for example, content objects are exported and re-imported via the package manager, all date/time attributes are set incorrectly (e.g. in german: "Zuletzt geändert: 01.01.1970 01:00"). 

e.g. rfc1123Date

correct: Wed, 13 Dec 2023 08:55:04 GMT 
wrong: 50UTC13, 13 WedUTC2023-12-13T08:55:04+00:00 2023 08:55:04 8DecGMT

correct: Tue, 18 Sep 2018 20:00:00 GMT
wrong: GMT000000UTC, 18 thUTCZ 2018 20:00:00 20SepGMT

Notes on the possible formats:
- https://www.php.net/manual/en/function.strftime.php (strftime)
- https://www.php.net/manual/en/datetime.format.php (gmdate)