### PR TITLE
Updated: Minor fatal error bugfixes to setup process plus extra polish to wizard

### DIFF
--- a/design/standard/templates/setup/init/registration.tpl
+++ b/design/standard/templates/setup/init/registration.tpl
@@ -7,18 +7,18 @@
 {'<p>If you need to share knowledge, exchange tips with developers or simply find some improvement tricks, the eZ Community is the place to go.</p>
 <p>How do you access it?</p>
 <ul>
-  <li>Go on %share_link%share.ez.no%a%</li>
+  <li>Go on %share_link%share.se7enx.com%a%</li>
   <li>Click on Register (top of the page) and create your profile</li>
-  <li>Here you can check out the %blogs_link%blog posts%a%, %events_link%events%a%, %partners_link%partners%a%...</li>
+  <li>Here you can check out the %blogs_link%blog posts%a%, %articles_link%articles%a%, %forums_link%forums%a% ...</li>
 </ul></p>
 <p>We’re looking forward to seeing what you share with the Community!</p>'|i18n('design/standard/setup/init',
     null,
     hash(
         '%a%', '</a>',
-        '%share_link%', '<a href="http://share.ez.no/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">',
-        '%blogs_link%', '<a href="http://share.ez.no/blogs/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">',
-        '%events_link%', '<a href="http://share.ez.no/events/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">',
-        '%partners_link%', '<a href="http://share.ez.no/members-partners/find-a-partner/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">'
+        '%share_link%', '<a href="https://share.se7enx.com/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">',
+        '%blogs_link%', '<a href="https://share.se7enx.com/blogs/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">',
+        '%articles_link%', '<a href="https://share.se7enx.com/learn/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">',
+        '%forums_link%', '<a href="https://share.se7enx.com/forums/?utm_source=Setup%20Wizard&utm_medium=Setup%20Wizard&utm_campaign=Setup%20Wizard">'
     )
 )}
 

--- a/doc/6.0/php8.md
+++ b/doc/6.0/php8.md
@@ -1,0 +1,33 @@
+# PHP 8 support
+
+## PHP 8.0 support
+
+For the [2023.12.05 release](https://github.com/se7enxweb/ezpublish/releases/tag/v2023.13.05),
+eZ Publish received changes all over the code base, switching variable syntax to PHP 8 style, variable return type comparison checking before use errors under PHP 8.2, and more. 
+
+The reason is to achieve full PHP 8.0 support by avoiding the deprecation warnings when using PHP 8 syntax.
+
+Care has been taken to keep around compatibility functions in all known cases to avoid fatal errors
+for custom extensions, however to avoid warnings you might need to adapt your code as well.
+
+Common cases are classes extending `eZPersistentObject` or `eZDataType`.
+
+Further reading:
+- [www.php.net/manual/en/migration80.incompatible.php](https://www.php.net/manual/en/migration80.incompatible.php)
+- [www.php.net/manual/en/migration81.incompatible.php](https://www.php.net/manual/en/migration81.incompatible.php)
+
+## PHP 8.2 support
+
+Starting with the 2023.12 release, issues happening on PHP 8.1 and PHP 8.2 have been fixed, but in your own code (extensions) you'll
+also need to handle some of those.
+
+Further reading:
+- [www.php.net/manual/en/migration82.incompatible.php](https://www.php.net/manual/en/migration82.incompatible.php)
+
+## PHP 8.3 support
+
+Starting with the 2023.12 release, most issues happening on PHP 8.2 and PHP 8.3 have been fixed, but in your own code (extensions) you'll
+also need to handle some of those.
+
+Further reading:
+- [www.php.net/manual/en/migration83.incompatible.php](https://www.php.net/manual/en/migration83.incompatible.php)

--- a/kernel/setup/steps/ezstep_language_options.php
+++ b/kernel/setup/steps/ezstep_language_options.php
@@ -134,7 +134,7 @@ class eZStepLanguageOptions extends eZStepInstaller
 
             $regionalInfo = array();
             $regionalInfo['primary_language'] = $data['Primary'];
-            if ( !in_array( $data['Primary'], $data['Languages'] ) )
+            if ( !in_array( $data['Primary'], $data['Languages'] ?? [] ) )
                 $data['Languages'][] = $data['Primary'];
             $regionalInfo['languages'] = $data['Languages'];
             $regionalInfo['enable_unicode'] = true;

--- a/kernel/setup/steps/ezstep_site_types.php
+++ b/kernel/setup/steps/ezstep_site_types.php
@@ -390,7 +390,7 @@ class eZStepSiteTypes extends eZStepInstaller
 
         // Download packages that the site package requires.
         $downloadDependandPackagesResult = $this->downloadDependantPackages( $package );
-        return $downloadDependandPackagesResult == false ? false : !$downloaded;
+        return $downloadDependandPackagesResult == false ? false : $downloaded;
     }
 
     function init()

--- a/lib/eztemplate/classes/eztemplateforfunction.php
+++ b/lib/eztemplate/classes/eztemplateforfunction.php
@@ -103,7 +103,7 @@ class eZTemplateForFunction
         $loop->initVars();
 
         // loop header
-        $modifyLoopCounterCode = "\$for_firstval_$uniqid < \$for_lastval_$uniqid ? \$for_i_${uniqid}++ : \$for_i_${uniqid}--"; // . ";\n";
+        $modifyLoopCounterCode = "\$for_firstval_$uniqid < \$for_lastval_$uniqid ? \$for_i_{$uniqid}++ : \$for_i_{$uniqid}--"; // . ";\n";
         $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "for ( \$for_i_$uniqid = \$for_firstval_$uniqid ; ; $modifyLoopCounterCode )\n{" );
         $newNodes[] = eZTemplateNodeTool::createSpacingIncreaseNode();
         // Check for index


### PR DESCRIPTION
Hello Netgen,

Today I have patches from the recent ground breaking development collaboration between 7x and ZWEBB to deliver a 100% working eZ Publish on PHP 8.1+.

These changes sync to this date from our 7x 2023.12/main branches of this repository.

These changes prevent warnings on production with display_errors=On from within the template for function abstraction.

Also today is two key bugfixes to the default installation process to keep it working correctly for all users. 

The rest of the bugfixes are contained within ezpkg from the package server (7x; [6.0](https://packages.ezpublishlegacy.se7enx.com/ezpublish/6.0/6.0.0/)) and or also contained within composer installed extensions (from composer.json which we feel needs to be updated soon as well to keep everything in the eZ Publish System working 100% by default on first try. Affected extensions to date not yet updated in this fork composer configuration is ezstarrating, ezflow, ezdemo, ezwebin, ezgmaplocation, ezwt.