### PR TITLE
Update package.ini replace php8 incompatible package server URLs

### DIFF
--- a/settings/package.ini
+++ b/settings/package.ini
@@ -15,11 +15,11 @@ RepositoryDirectory=packages
 # If you want to use the old packages which were available in
 # versions prior to 3.9 use the following URL instead:
 # http://packages.ez.no/ezpublish/3.9legacypackages
-RemotePackagesIndexURL=http://packages.ez.no/ezpublish/5.4/5.4.0
+RemotePackagesIndexURL=http://packages.ezpublishlegacy.se7enx.com/ezpublish/6.0/6.0.0
 # If RemotePackagesIndexURL is empty, the RemotePackagesIndexURLBase setting
 # will be used, appended with the eZ Publish version numbers, like
 # RemotePackagesIndexURLBase/x.y/x.y.zalpha1
-RemotePackagesIndexURLBase=http://packages.ez.no/ezpublish
+RemotePackagesIndexURLBase=https://packages.ezpublishlegacy.se7enx.com/ezpublish
 # Vendor name of the eZ Publish package directory
 Vendor=eZ-systems
 


### PR DESCRIPTION
This was required by the fact we needed to issue php8 bugfixes to the site package (tar.gz folder) contents (installer steps). This gives us more freedom in the light that anyone can fork the package server repository and contribute changes to the site type step ini file changes and content population for existing and even now brand new site packages updated to 2024. This has been tested as working with the latest improvements from the now released eZ Publish 6.0 (Maintained By 7x) default installation process refactoring work.