### PR TITLE
Update dashboard.ini disable with comment the community_activity Admi…

### DIFF
--- a/settings/dashboard.ini
+++ b/settings/dashboard.ini
@@ -6,7 +6,7 @@ DashboardBlocks[]=pending_list
 DashboardBlocks[]=drafts
 DashboardBlocks[]=latest_content
 DashboardBlocks[]=all_latest_content
-DashboardBlocks[]=community_activity
+# DashboardBlocks[]=community_activity
 # DashboardBlocks[]=wishlist
 
 # [DashboardBlock_example]


### PR DESCRIPTION
…n Dashboard Block As Non-Function

Update dashboard.ini disable with comment the community_activity Admin Dashboard Block As Non-Function (Based on share.ez.no rss feed and now broken js). This change brings us one step closer to a cleaner admin with less distractions on broken features right on the admin dashboard ;).