### PR TITLE
PHP 8.0: Preventing Fatal error in PHP 8 for ezmatrix datatype

### DIFF
--- a/kernel/classes/datatypes/ezmatrix/ezmatrix.php
+++ b/kernel/classes/datatypes/ezmatrix/ezmatrix.php
@@ -691,10 +691,10 @@ class eZMatrix
     */
     function decodeXML( $xmlString )
     {
-        $dom = new DOMDocument( '1.0', 'utf-8' );
-        $success = $dom->loadXML( $xmlString );
         if ( $xmlString != "" )
         {
+            $dom = new DOMDocument( '1.0', 'utf-8' );
+            $success = $dom->loadXML( $xmlString );
             // set the name of the node
             $nameArray = $dom->getElementsByTagName( "name" );
             $this->setName( $nameArray->item( 0 )->textContent );

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -217,6 +217,25 @@ class eZContentObjectAttribute extends eZPersistentObject
                                                     $asObject);
     }
 
+    /**
+     * Returns the attribute data for $attr, this is either returned from the
+     * member variables or a member function depending on whether the definition
+     * field or function attributes matched.
+     *
+     * @param string $attr
+     * @param bool $noFunction
+     * @return mixed
+     */
+    public function attribute( $attr, $noFunction = false )
+    {
+        // avoiding returning null values for data_text
+        if($attr == 'data_text' && $this->DataText === null)
+        {
+            return '';
+        }
+        return parent::attribute( $attr, $noFunction );
+    }
+
     /*!
      \return the attributes with alternative translations for the current attribute version and class attribute id
     */


### PR DESCRIPTION
Preventing Fatal error in PHP 8 for ezmatrix datatype when data_text is an empty string or null.

We want to standardize the data_text default value to an empty string because in PHP 8 most of operations with string will throw a Fatal error when passing null. The data_text value is initialized with a null value when adding a new attribute to an existing content class.